### PR TITLE
Release 1.1.0

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,43 @@
+name: Build and Publish to Docker Hub
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            logoff/almanac-bot:latest
+            logoff/almanac-bot:${{ steps.version.outputs.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Configuration (contains secrets)
 config.ini
+docker-compose.swarm.yaml
 
 # Logs
 *.log

--- a/README.md
+++ b/README.md
@@ -193,6 +193,56 @@ just help  # Show all available commands
                       PostgreSQL
 ```
 
+## Production Deployment (Docker Swarm)
+
+For production deployment on Docker Swarm:
+
+### 1. Create Docker secrets
+
+```sh
+# Create secret from your config.ini file
+docker secret create almanac_config /path/to/config.ini
+```
+
+### 2. Prepare the stack directory
+
+```sh
+mkdir -p /path/to/almanac-bot/{init_db,postgres}
+
+# Copy the database init script (creates schema on first run)
+cp postgres/init-ephemeris-db.sh /path/to/almanac-bot/postgres/
+
+# Copy your ephemeris CSV data
+cp your_data.csv /path/to/almanac-bot/init_db/init_db.csv
+```
+
+### 3. Configure the stack
+
+```sh
+# Copy the example and adjust paths
+cp docker-compose.swarm.example.yaml /path/to/almanac-bot/docker-compose.swarm.yaml
+
+# Edit the file and update volume paths to match your directory
+```
+
+### 4. Deploy
+
+```sh
+docker stack deploy -c /path/to/almanac-bot/docker-compose.swarm.yaml almanac
+```
+
+### 5. Load ephemeris data into database
+
+After the stack is running, load the CSV data into PostgreSQL:
+
+```sh
+# Find the bot container
+docker ps | grep almanac-bot
+
+# Load the CSV into the database
+docker exec <container_id> uv run python -m typer almanacbot.data_loader run
+```
+
 ## License
 
 MIT

--- a/docker-compose.swarm.example.yaml
+++ b/docker-compose.swarm.example.yaml
@@ -1,0 +1,75 @@
+# Docker Swarm stack for almanac-bot
+# Copy this file to docker-compose.swarm.yaml and adjust paths for your environment
+#
+# Prerequisites:
+# 1. Create Docker secrets:
+#    docker secret create almanac_config /path/to/config.ini
+#
+# 2. Copy data files to the VM:
+#    - init_db/*.csv files to /path/to/stacks/almanac-bot/init_db/
+#    - postgres/init-ephemeris-db.sh to /path/to/stacks/almanac-bot/postgres/
+#
+# 3. Deploy the stack:
+#    docker stack deploy -c docker-compose.swarm.yaml almanac
+
+services:
+  almanac-bot:
+    image: logoff/almanac-bot:latest
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    secrets:
+      - source: almanac_config
+        target: /almanac-bot/config.ini
+    volumes:
+      - /path/to/stacks/almanac-bot/init_db/:/almanac-bot/init_db/:ro
+    labels:
+      ofelia.enabled: "true"
+      ofelia.job-exec.almanac.schedule: "0 0 8 * * *"
+      ofelia.job-exec.almanac.command: "uv run python -m almanacbot.almanacbot"
+    entrypoint: ["tail", "-f", "/dev/null"]
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+
+  ofelia:
+    image: mcuadros/ofelia:latest
+    restart: unless-stopped
+    depends_on:
+      - almanac-bot
+    command: daemon --docker
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    deploy:
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
+
+  postgres:
+    image: postgres:17.3-alpine
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U almanac -d almanac"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - /path/to/stacks/almanac-bot/postgres/:/docker-entrypoint-initdb.d/:ro
+    environment:
+      POSTGRES_USER: almanac
+      POSTGRES_PASSWORD: almanac
+      POSTGRES_DB: almanac
+    deploy:
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
+
+secrets:
+  almanac_config:
+    external: true
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary

Add Docker Swarm deployment support and Docker Hub CI/CD publishing.

### Changes
- Add `docker-compose.swarm.example.yaml` for production deployment
- Add `.github/workflows/docker-publish.yaml` for multi-arch image publishing (amd64/arm64)
- Update `.gitignore` to exclude local swarm config
- Add deployment documentation to README

### Setup Required
Repository secrets needed for Docker Hub publishing:
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`